### PR TITLE
Check if lang key exists before applying name masking

### DIFF
--- a/src/main/java/net/smileycorp/dynaores/common/item/ItemBlockRawOre.java
+++ b/src/main/java/net/smileycorp/dynaores/common/item/ItemBlockRawOre.java
@@ -17,9 +17,16 @@ public class ItemBlockRawOre extends ItemBlock implements IOreItem {
     }
     
     @Override
+    @SuppressWarnings("deprecation")
     public String getItemStackDisplayName(ItemStack stack) {
-        return I18n.translateToLocalFormatted("items.dynaores.RawOreBlock.name",
-                I18n.translateToLocal(entry.getLocalizedName()).replace("Ingot", "").trim()).trim();
+        // If a lang key exists for this Raw Ore Block, use it.
+        if (I18n.canTranslate(stack.getUnlocalizedName() + ".name")) {
+            return super.getItemStackDisplayName(stack);
+        }
+        else { // If not, generate a name that makes sense (only for English tho. In other languages it turns into "Block of Raw Iron Ingot", etc.)
+            return I18n.translateToLocalFormatted("items.dynaores.RawOreBlock.name",
+                    I18n.translateToLocal(entry.getLocalizedName()).replace("Ingot", "").trim()).trim();
+        }
     }
     
     @Override

--- a/src/main/java/net/smileycorp/dynaores/common/item/ItemRawOre.java
+++ b/src/main/java/net/smileycorp/dynaores/common/item/ItemRawOre.java
@@ -20,9 +20,17 @@ public class ItemRawOre extends Item implements IOreItem {
     }
     
     @Override
+    @SuppressWarnings("deprecation")
     public String getItemStackDisplayName(ItemStack stack) {
-        return I18n.translateToLocalFormatted("items.dynaores.RawOre.name",
-                I18n.translateToLocal(entry.getLocalizedName()).replace("Ingot", "").trim()).trim();
+        // If a lang key exists for this Raw Ore, behave as default.
+        if (I18n.canTranslate(stack.getUnlocalizedName() + ".name")) {
+            return super.getItemStackDisplayName(stack);
+        }
+        else { // If not, generate a name that makes sense (only for English tho. In other languages it turns into "Raw Iron Ingot", etc.)
+            return I18n.translateToLocalFormatted("items.dynaores.RawOre.name",
+                    I18n.translateToLocal(entry.getLocalizedName()).replace("Ingot", "").trim()).trim();
+        }
+        
     }
     
     @Override

--- a/src/main/resources/assets/dynaores/lang/en_us.lang
+++ b/src/main/resources/assets/dynaores/lang/en_us.lang
@@ -3,3 +3,11 @@ items.dynaores.RawGem.name=Uncut %1$s
 items.dynaores.RawOreBlock.name=Block of Raw %1$s
 items.dynaores.RawGemBlock.name=Uncut Block of %1$s
 itemGroup.dynaores.tab=Raw Ores
+
+## Individual raw ores
+# Iron
+item.dynaores.RawIron.name=Raw Iron
+tile.dynaores.RawIronBlock.name=Block of Raw Iron
+# Gold
+item.dynaores.RawGold.name=Raw Gold
+tile.dynaores.RawGoldBlock.name=Block of Raw Gold

--- a/src/main/resources/assets/dynaores/lang/es_mx.lang
+++ b/src/main/resources/assets/dynaores/lang/es_mx.lang
@@ -1,0 +1,14 @@
+## Translated by KameiB. Jul/2024
+items.dynaores.RawOre.name=%1$s crudo
+items.dynaores.RawGem.name=%1$s no cortado
+items.dynaores.RawOreBlock.name=Bloque de %1$s crudo
+items.dynaores.RawGemBlock.name=Bloque de %1$s no cortado
+itemGroup.dynaores.tab=Raw Ores
+
+## Individual raw ores
+# Iron
+item.dynaores.RawIron.name=Hierro crudo
+tile.dynaores.RawIronBlock.name=Bloque de hierro crudo
+# Gold
+item.dynaores.RawGold.name=Oro crudo
+tile.dynaores.RawGoldBlock.name=Bloque de oro crudo


### PR DESCRIPTION
Raw Ores and Raw Ore Blocks now first check if its lang key exists and use it, before trying to use the custom name masking method (which works only for English tho. In other languages it turns into "Raw Iron Ingot", etc.).  
Added lang keys for Iron and Gold, so modpack creators have examples and create their own lang keys in the resources folder.